### PR TITLE
Feature:#41 마이페이지 유저 정보 조회시 카테고리랑 키워드 같이 보내도록 수정

### DIFF
--- a/src/main/java/org/mjulikelion/engnews/dto/response/user/MypageDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/user/MypageDto.java
@@ -2,7 +2,13 @@ package org.mjulikelion.engnews.dto.response.user;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.mjulikelion.engnews.dto.response.category.CategoryResponseDto;
+import org.mjulikelion.engnews.dto.response.keyword.KeywordResponseDto;
+import org.mjulikelion.engnews.entity.Category;
+import org.mjulikelion.engnews.entity.Keyword;
+import org.mjulikelion.engnews.entity.User;
 
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -11,4 +17,22 @@ public class MypageDto {
     private UUID id;
     private String name;
     private String email;
+
+    private List<CategoryResponseDto> categories;
+    private List<KeywordResponseDto> keywords;
+
+    public static MypageDto from(User user, List<Keyword> keywords, List<Category> categories) {
+        return MypageDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .categories(categories.stream()
+                        .map(CategoryResponseDto::from)
+                        .toList())
+                .keywords(keywords.stream()
+                        .map(KeywordResponseDto::from)
+                        .toList())
+                .build();
+    }
+
 }

--- a/src/main/java/org/mjulikelion/engnews/service/UserService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/UserService.java
@@ -3,13 +3,19 @@ package org.mjulikelion.engnews.service;
 import lombok.RequiredArgsConstructor;
 import org.mjulikelion.engnews.authentication.PasswordHashEncryption;
 import org.mjulikelion.engnews.dto.response.user.MypageDto;
+import org.mjulikelion.engnews.entity.Category;
+import org.mjulikelion.engnews.entity.Keyword;
 import org.mjulikelion.engnews.entity.User;
 import org.mjulikelion.engnews.exception.ConflictException;
 import org.mjulikelion.engnews.exception.ErrorCode;
 import org.mjulikelion.engnews.exception.NotFoundException;
 import org.mjulikelion.engnews.exception.UnauthorizedException;
+import org.mjulikelion.engnews.repository.CategoryRepository;
+import org.mjulikelion.engnews.repository.KeywordRepository;
 import org.mjulikelion.engnews.repository.UserRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,13 +23,18 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordHashEncryption passwordHashEncryption;
+    private final CategoryRepository categoryRepository;
+    private final KeywordRepository keywordRepository;
 
     public MypageDto getMypage(User user) {
-        return MypageDto.builder()
-                .id(user.getId())
-                .name(user.getName())
-                .email(user.getEmail())
-                .build();
+
+        // 유저와 연결된 카테고리 리스트 가져오기
+        List<Category> categories = categoryRepository.findAllByUser(user);
+
+        // 카테고리 리스트와 연결된 키워드 가져오기
+        List<Keyword> keywords = keywordRepository.findAllByCategoryIn(categories);
+
+        return MypageDto.from(user, keywords, categories);
     }
 
     public void validateIsPasswordMatches(String requestedPassword, String userPassword) {


### PR DESCRIPTION
## 🚀Description
마이페이지 유저 정보 조회시 응답 data출력 요소 변경
수정 전 : 유저id + name + password
수정 후 :  유저id + name +password + 카테고리 리스트 + 키워드 리스트

## 🛠️Changes
### Service
- [x] UserService의 getMypage메서드 수정

### Dto
- [x] MypageDto수정

## 🏷memo
기능과 별개로 MypageDto 빌드를 UserService에서 하고 있었는데 MypageDto에서 빌드하도록 수정함

close #41 