### PR TITLE
Feature/#58 키워드 조회 로직 변경

### DIFF
--- a/src/main/java/org/mjulikelion/engnews/controller/keywordController.java
+++ b/src/main/java/org/mjulikelion/engnews/controller/keywordController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.mjulikelion.engnews.authentication.AuthenticatedUser;
 import org.mjulikelion.engnews.dto.request.keyword.KeywordDto;
 import org.mjulikelion.engnews.dto.response.ResponseDto;
-import org.mjulikelion.engnews.dto.response.keyword.KeywordsListResponseDto;
+import org.mjulikelion.engnews.dto.response.keyword.CategoryKeywordListResponseDto;
 import org.mjulikelion.engnews.entity.User;
 import org.mjulikelion.engnews.service.KeywordService;
 import org.springframework.http.HttpStatus;
@@ -31,8 +31,8 @@ public class keywordController {
 
     //특정 카테고리와 관련된 키워드 전체 조회 컨트롤러
     @GetMapping("/{categoryId}")
-    public ResponseEntity<ResponseDto<KeywordsListResponseDto>> getKeyword(@AuthenticatedUser User user,@PathVariable UUID categoryId){
-        KeywordsListResponseDto keywords=keywordService.getKeyword(user,categoryId);
+    public ResponseEntity<ResponseDto<CategoryKeywordListResponseDto>> getKeyword(@AuthenticatedUser User user,@PathVariable UUID categoryId){
+        CategoryKeywordListResponseDto keywords=keywordService.getKeyword(user,categoryId);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "키워드 조회 완료",keywords), HttpStatus.OK);
     }
 

--- a/src/main/java/org/mjulikelion/engnews/dto/response/keyword/CategoryKeywordListResponseDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/keyword/CategoryKeywordListResponseDto.java
@@ -1,0 +1,21 @@
+package org.mjulikelion.engnews.dto.response.keyword;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.mjulikelion.engnews.entity.Keyword;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CategoryKeywordListResponseDto {
+    private List<CategoryKeywordResponseDto> keywords;
+
+    public static CategoryKeywordListResponseDto from(List<Keyword> keywords){
+        return CategoryKeywordListResponseDto.builder()
+                .keywords(keywords.stream()
+                        .map(CategoryKeywordResponseDto::from)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/org/mjulikelion/engnews/dto/response/keyword/CategoryKeywordResponseDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/keyword/CategoryKeywordResponseDto.java
@@ -1,0 +1,28 @@
+package org.mjulikelion.engnews.dto.response.keyword;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.mjulikelion.engnews.entity.Keyword;
+import org.mjulikelion.engnews.entity.type.CategoryType;
+
+import java.util.UUID;
+
+
+//카테고리별 키워드 조회시 전달되는 데이터
+@Getter
+@Builder
+public class CategoryKeywordResponseDto {
+    private CategoryType categoryOption;
+    private UUID userCategoryId;
+    private String keyword;
+    private UUID keywordId;
+
+    public static  CategoryKeywordResponseDto from(Keyword keyword){
+        return CategoryKeywordResponseDto.builder()
+                .categoryOption(keyword.getCategory().getCategoryOptions().getCategoryType())    //카테고리옵션 아이디
+                .userCategoryId(keyword.getCategory().getId())  //유저가 설정한 키워드
+                .keyword(keyword.getKeyword())  //키워드 이름
+                .keywordId(keyword.getId())    //키워드 아이디
+                .build();
+    }
+}

--- a/src/main/java/org/mjulikelion/engnews/dto/response/keyword/KeywordResponseDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/keyword/KeywordResponseDto.java
@@ -3,19 +3,25 @@ package org.mjulikelion.engnews.dto.response.keyword;
 import lombok.Builder;
 import lombok.Getter;
 import org.mjulikelion.engnews.entity.Keyword;
+import org.mjulikelion.engnews.entity.type.CategoryType;
 
 import java.util.UUID;
 
 @Getter
 @Builder
 public class KeywordResponseDto {
-    private UUID id;
+    private CategoryType categoryOption;
+    private UUID userCategoryId;
     private String keyword;
+    private UUID keywordId;
+
 
     public static  KeywordResponseDto from(Keyword keyword){
         return KeywordResponseDto.builder()
-                .id(keyword.getId())
-                .keyword(keyword.getKeyword())
+                .categoryOption(keyword.getCategory().getCategoryOptions().getCategoryType())    //카테고리옵션 아이디
+                .userCategoryId(keyword.getCategory().getId())  //유저가 설정한 키워드
+                .keyword(keyword.getKeyword())  //키워드 이름
+                .keywordId(keyword.getId())    //키워드 아이디
                 .build();
     }
 }

--- a/src/main/java/org/mjulikelion/engnews/dto/response/keyword/KeywordResponseDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/keyword/KeywordResponseDto.java
@@ -10,18 +10,13 @@ import java.util.UUID;
 @Getter
 @Builder
 public class KeywordResponseDto {
-    private CategoryType categoryOption;
-    private UUID userCategoryId;
+    private UUID id;
     private String keyword;
-    private UUID keywordId;
-
 
     public static  KeywordResponseDto from(Keyword keyword){
         return KeywordResponseDto.builder()
-                .categoryOption(keyword.getCategory().getCategoryOptions().getCategoryType())    //카테고리옵션 아이디
-                .userCategoryId(keyword.getCategory().getId())  //유저가 설정한 키워드
-                .keyword(keyword.getKeyword())  //키워드 이름
-                .keywordId(keyword.getId())    //키워드 아이디
+                .id(keyword.getId())
+                .keyword(keyword.getKeyword())
                 .build();
     }
 }

--- a/src/main/java/org/mjulikelion/engnews/service/KeywordService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/KeywordService.java
@@ -3,7 +3,7 @@ package org.mjulikelion.engnews.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mjulikelion.engnews.dto.request.keyword.KeywordDto;
-import org.mjulikelion.engnews.dto.response.keyword.KeywordsListResponseDto;
+import org.mjulikelion.engnews.dto.response.keyword.CategoryKeywordListResponseDto;
 import org.mjulikelion.engnews.entity.Category;
 import org.mjulikelion.engnews.entity.Keyword;
 import org.mjulikelion.engnews.entity.User;
@@ -36,13 +36,13 @@ public class KeywordService {
         keywordRepository.save(keyword);
     }
 
-    public KeywordsListResponseDto getKeyword(User user, UUID categoryId){
+    public CategoryKeywordListResponseDto getKeyword(User user, UUID categoryId){
         Category category = categoryRepository.findByUserAndId(user,categoryId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.CATEGORY_NOT_FOUND));
 
         List<Keyword> keywords = keywordRepository.findAllByCategory(category);
 
-        return KeywordsListResponseDto.from(keywords);
+        return CategoryKeywordListResponseDto.from(keywords);
     }
 
     public void deleteKeyword(User user, UUID keywordId) {


### PR DESCRIPTION
## 🚀Description
카테고리별 키워드 조회시
변경 전 :  유저 카테고리 id+키워드 이름
변경 후 :  카테고리 옵션 + 유저 카테고리 id + 키워드 이름 + 키워드id

## 🛠️Changes
### Dto
- [x] getKeyword컨트롤러  반환형을 CategoryKeywordListResponseDto로 변경
- [x] getKeyword서비스  반환형을 CategoryKeywordListResponseDto로 변경

## 📌Add
- [x] CategoryKeywordResponseDto
- [x] CategoryKeywordListResponseDto

## 🏷memo

close #58 