### PR TITLE
Feature/#49 기사 요약,번역 기능 연결

### DIFF
--- a/src/main/java/org/mjulikelion/engnews/config/AuthenticationConfig.java
+++ b/src/main/java/org/mjulikelion/engnews/config/AuthenticationConfig.java
@@ -19,7 +19,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .addPathPatterns("/users/**","/words-like/**","/categories/**","/keywords/**","/news/**", "/articles-like/**", "/news/nyt/keyword","/news/naver/keyword")
+                .addPathPatterns("/users/**","/words-like/**","/categories/**","/keywords/**","/news/**", "/articles-like/**", "/news/nyt/keyword","/news/naver/keyword","/try-summarize/**","/try-translate/**")
                 .excludePathPatterns("/categories/naver", "/categories/nyt", "/news/nyt/**","/news/naver/categories","/news/naver","/news/naver/top5");
     }
 

--- a/src/main/java/org/mjulikelion/engnews/controller/SummarizeController.java
+++ b/src/main/java/org/mjulikelion/engnews/controller/SummarizeController.java
@@ -1,0 +1,26 @@
+package org.mjulikelion.engnews.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.mjulikelion.engnews.authentication.AuthenticatedUser;
+import org.mjulikelion.engnews.dto.ai.FeedbackDto;
+import org.mjulikelion.engnews.dto.ai.TryDto;
+import org.mjulikelion.engnews.dto.response.ResponseDto;
+import org.mjulikelion.engnews.entity.User;
+import org.mjulikelion.engnews.service.SummarizeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/try-summarize")
+public class SummarizeController {
+
+    private final SummarizeService summarizeService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDto<FeedbackDto>> trySummarize(@AuthenticatedUser User user,@RequestBody TryDto tryDto) {
+        FeedbackDto feedback=summarizeService.trySummarize(user,tryDto);
+        return ResponseEntity.ok(ResponseDto.res(HttpStatus.OK, "기사 요약하고 피드백 받기 성공", feedback));
+    }
+}

--- a/src/main/java/org/mjulikelion/engnews/controller/TranslateController.java
+++ b/src/main/java/org/mjulikelion/engnews/controller/TranslateController.java
@@ -1,0 +1,30 @@
+package org.mjulikelion.engnews.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.mjulikelion.engnews.authentication.AuthenticatedUser;
+import org.mjulikelion.engnews.dto.ai.FeedbackDto;
+import org.mjulikelion.engnews.dto.ai.TryDto;
+import org.mjulikelion.engnews.dto.response.ResponseDto;
+import org.mjulikelion.engnews.entity.User;
+import org.mjulikelion.engnews.service.TranslateService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/try-translate")
+public class TranslateController {
+    private final TranslateService translateService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDto<FeedbackDto>> tryTranslate(@AuthenticatedUser User user, @RequestBody TryDto tryDto) {
+        FeedbackDto feedback=translateService.tryTranslate(user,tryDto);
+        return ResponseEntity.ok(ResponseDto.res(HttpStatus.OK, "기사 번역하고 피드백 받기 성공", feedback));
+    }
+
+
+}

--- a/src/main/java/org/mjulikelion/engnews/dto/ai/FeedbackDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/ai/FeedbackDto.java
@@ -1,0 +1,16 @@
+package org.mjulikelion.engnews.dto.ai;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedbackDto {
+    private String gpt_answer;
+
+    public static FeedbackDto from(String feedBack){
+        return FeedbackDto.builder()
+                .gpt_answer(feedBack)
+                .build();
+    }
+}

--- a/src/main/java/org/mjulikelion/engnews/dto/ai/TryDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/ai/TryDto.java
@@ -1,0 +1,15 @@
+package org.mjulikelion.engnews.dto.ai;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TryDto {
+
+    String message;
+    String news_content;
+
+}

--- a/src/main/java/org/mjulikelion/engnews/service/SummarizeService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/SummarizeService.java
@@ -1,0 +1,37 @@
+package org.mjulikelion.engnews.service;
+
+import lombok.RequiredArgsConstructor;
+import org.mjulikelion.engnews.dto.ai.FeedbackDto;
+import org.mjulikelion.engnews.dto.ai.TryDto;
+import org.mjulikelion.engnews.entity.User;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class SummarizeService {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String trySummarizeURL = "http://43.203.141.103:8000/try-summarize";
+
+    public FeedbackDto trySummarize(User user, TryDto tryDto){
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON); //Json형식
+        headers.add("user", String.valueOf(user.getId()));
+
+        // HTTP 요청 엔터티 생성 (헤더 + 바디)
+        HttpEntity<TryDto> entity = new HttpEntity<>(tryDto, headers);
+
+        // POST 요청 전송
+        ResponseEntity<String> response = restTemplate.exchange(trySummarizeURL, HttpMethod.POST, entity, String.class);
+
+
+        FeedbackDto feedback = FeedbackDto.builder()
+                .gpt_answer(response.getBody())
+                .build();
+
+        return feedback;
+    }
+}

--- a/src/main/java/org/mjulikelion/engnews/service/TranslateService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/TranslateService.java
@@ -1,0 +1,37 @@
+package org.mjulikelion.engnews.service;
+
+import lombok.RequiredArgsConstructor;
+import org.mjulikelion.engnews.dto.ai.FeedbackDto;
+import org.mjulikelion.engnews.dto.ai.TryDto;
+import org.mjulikelion.engnews.entity.User;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class TranslateService {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String translateURL = "http://43.203.141.103:8000/try-translate";
+
+    public FeedbackDto tryTranslate(User user, TryDto tryDto){
+
+        // HTTP 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON); //Json형식
+        headers.add("user", String.valueOf(user.getId()));
+
+        // HTTP 요청 엔터티 생성 (헤더 + 바디)
+        HttpEntity<TryDto> entity = new HttpEntity<>(tryDto, headers);
+
+        // POST 요청 전송
+        ResponseEntity<String> response = restTemplate.exchange(translateURL, HttpMethod.POST, entity, String.class);
+
+
+        FeedbackDto feedback = FeedbackDto.builder()
+                .gpt_answer(response.getBody())
+                .build();
+
+        return feedback;
+    }
+}


### PR DESCRIPTION
## 🚀Description
머신러닝의 기사 요약, 번역 API와 연결

## 🛠️Changes
- [x] addInterceptors

## 📌Add
- [x] FeedbackDto
- [x] TryDto
- [x] SummarizeController
- [x] SummarizeService
- [x] TranslateController
- [x] TranslateService

## 🏷memo

1. Post로 프론트에게 message, news_content를 입력 받음 (summarizeDto)
	message -> 유저의 채팅 창  (요약 내용 or 번역내용)
	news_content -> 뉴스 기사 내용 (기사 원본)

2. Post로 AI서버에 message, news_content를 보낸다 (똑같이summarizeDto)

3. AI서버에 응답을 받는다 (feedbackDto)
	gpt_answer -> 피드백

4.Post로 feedbackDto를 프론트에 전송한다.

close #49 