### PR TITLE
Feature/#89 기사 단건 조회시 articleId반환하도록 수정

### DIFF
--- a/src/main/java/org/mjulikelion/engnews/controller/ArticleLikeController.java
+++ b/src/main/java/org/mjulikelion/engnews/controller/ArticleLikeController.java
@@ -12,7 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @RestController
 @AllArgsConstructor
@@ -40,9 +41,10 @@ public class ArticleLikeController {
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.CREATED, "기사 찜하기 완료"), HttpStatus.CREATED);
     }
 
-    @DeleteMapping("/{articleId}")
-    public ResponseEntity<ResponseDto<Void>> deleteArticleLikeById(@AuthenticatedUser User user, @PathVariable UUID articleId) {
-        articleLikeService.deleteArticleLikeById(user, articleId);
+    @DeleteMapping
+    public ResponseEntity<ResponseDto<Void>> deleteArticleLikeById(@AuthenticatedUser User user,@RequestParam String url) {
+        String decodedUrl = URLDecoder.decode(url, StandardCharsets.UTF_8);
+        articleLikeService.deleteArticleLikeById(user, decodedUrl);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "찜한 뉴스 삭제 완료"), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/mjulikelion/engnews/dto/response/articleLike/ArticleLikeResponseDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/articleLike/ArticleLikeResponseDto.java
@@ -18,7 +18,7 @@ public class ArticleLikeResponseDto {
     public static ArticleLikeResponseDto from(ArticleLike articleLike, String title, String imageUrl, String content) {
         return ArticleLikeResponseDto.builder()
                 .id(articleLike.getId())
-                .originalUrl(articleLike.getOriginal_url())
+                .originalUrl(articleLike.getOriginalUrl())
                 .title(title)
                 .imageUrl(imageUrl)
                 .content(content)
@@ -28,7 +28,7 @@ public class ArticleLikeResponseDto {
     public static ArticleLikeResponseDto from(ArticleLike articleLike, String title, String content) {
         return ArticleLikeResponseDto.builder()
                 .id(articleLike.getId())
-                .originalUrl(articleLike.getOriginal_url())
+                .originalUrl(articleLike.getOriginalUrl())
                 .title(title)
                 .imageUrl(null)
                 .content(content)

--- a/src/main/java/org/mjulikelion/engnews/entity/ArticleLike.java
+++ b/src/main/java/org/mjulikelion/engnews/entity/ArticleLike.java
@@ -14,8 +14,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "article_like")
 public class ArticleLike extends BaseEntity {
 
-    @Column(nullable = false)
-    private String original_url;
+    @Column(name = "original_url", nullable = false)
+    private String originalUrl;
 
     @Column(nullable = false)
     private String news;

--- a/src/main/java/org/mjulikelion/engnews/repository/ArticleLikeRepository.java
+++ b/src/main/java/org/mjulikelion/engnews/repository/ArticleLikeRepository.java
@@ -12,4 +12,5 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, UUID> 
     Optional<ArticleLike> findByUserAndId(User user, UUID articleLikeId);
     List<ArticleLike> findAllByUserAndNews(User user, String news);
     List<ArticleLike> findAllByUser(User user);
+    Optional<ArticleLike> findByOriginalUrlAndUser(String originalUrl, User user);
 }

--- a/src/main/java/org/mjulikelion/engnews/service/ArticleLikeService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/ArticleLikeService.java
@@ -26,7 +26,7 @@ public class ArticleLikeService {
 
         List<ArticleLikeResponseDto> articleLikeDtos = articleLikes.stream()
                 .map(articleLike -> {
-                    String[] titleAndImageAndContent = getTitleImageAndContentFromUrl(articleLike.getOriginal_url());
+                    String[] titleAndImageAndContent = getTitleImageAndContentFromUrl(articleLike.getOriginalUrl());
                     return ArticleLikeResponseDto.from(
                             articleLike,
                             titleAndImageAndContent[0],
@@ -46,7 +46,7 @@ public class ArticleLikeService {
 
         List<ArticleLikeResponseDto> articleLikeDtos = articleLikes.stream()
                 .map(articleLike -> {
-                    String[] titleAndImageAndContent = getTitleImageAndContentFromUrl(articleLike.getOriginal_url());
+                    String[] titleAndImageAndContent = getTitleImageAndContentFromUrl(articleLike.getOriginalUrl());
                     return ArticleLikeResponseDto.from(
                             articleLike,
                             titleAndImageAndContent[0],
@@ -87,14 +87,14 @@ public class ArticleLikeService {
     public void saveArticleLike(User user, String originalUrl, String news) {
         ArticleLike articleLike = ArticleLike.builder()
                 .user(user)
-                .original_url(originalUrl)
+                .originalUrl(originalUrl)
                 .news(news)
                 .build();
         articleLikeRepository.save(articleLike);
     }
 
-    public void deleteArticleLikeById(User user, UUID articleLikeId) {
-        ArticleLike articleLike = articleLikeRepository.findByUserAndId(user, articleLikeId)
+    public void deleteArticleLikeById(User user, String url) {
+        ArticleLike articleLike = articleLikeRepository.findByOriginalUrlAndUser( url,user)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.ARTICLE_LIKE_NOT_FOUND));
         articleLikeRepository.delete(articleLike);
     }

--- a/src/main/java/org/mjulikelion/engnews/service/NYTNewsService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/NYTNewsService.java
@@ -142,7 +142,7 @@ public class NYTNewsService {
 
         // for 루프를 사용하여 각 ArticleLike의 original_url을 추출
         for (ArticleLike articleLike : articleLikes) {
-            urls.add(articleLike.getOriginal_url());
+            urls.add(articleLike.getOriginalUrl());
         }
 
         boolean isArticleLike = urls.contains(url);

--- a/src/main/java/org/mjulikelion/engnews/service/NaverNewsService.java
+++ b/src/main/java/org/mjulikelion/engnews/service/NaverNewsService.java
@@ -151,7 +151,7 @@ public class NaverNewsService {
 
         // for 루프를 사용하여 각 ArticleLike의 original_url을 추출
         for (ArticleLike articleLike : articleLikes) {
-            urls.add(articleLike.getOriginal_url());
+            urls.add(articleLike.getOriginalUrl());
         }
 
         boolean isArticleLike = urls.contains(url);


### PR DESCRIPTION
## 🚀Description
찜한기사 삭제시 url로 삭제하기

## 🛠️Changes
### Controller
- [x] deleteArticleLikeById

- [x] findByOriginalUrlAndUser

### 기타
 - [x] original_url -> originalUrl 로 변수명 수정

## 🏷memo

close #89 