### PR TITLE
Feature/#102 NYT 단건 기사 조회 로직 수정

### DIFF
--- a/src/main/java/org/mjulikelion/engnews/controller/NYTNewsController.java
+++ b/src/main/java/org/mjulikelion/engnews/controller/NYTNewsController.java
@@ -3,7 +3,7 @@ package org.mjulikelion.engnews.controller;
 import lombok.RequiredArgsConstructor;
 import org.mjulikelion.engnews.authentication.AuthenticatedUser;
 import org.mjulikelion.engnews.dto.response.ResponseDto;
-import org.mjulikelion.engnews.dto.response.article.ArticleDto;
+import org.mjulikelion.engnews.dto.response.article.ArticleNytDto;
 import org.mjulikelion.engnews.dto.response.article.CategoryArticleDto;
 import org.mjulikelion.engnews.entity.User;
 import org.mjulikelion.engnews.service.NYTNewsService;
@@ -33,8 +33,8 @@ public class NYTNewsController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDto<ArticleDto>> getNYTNews(@AuthenticatedUser User user,@RequestParam String url) {
-        ArticleDto article=nytService.getNYTNews(user, url);
+    public ResponseEntity<ResponseDto<ArticleNytDto>> getNYTNews(@AuthenticatedUser User user, @RequestParam String url) {
+        ArticleNytDto article = nytService.getNYTNews(user, url);
         return ResponseEntity.ok(ResponseDto.res(HttpStatus.OK, "NYT 기사 단건 조회 성공", article));
     }
 

--- a/src/main/java/org/mjulikelion/engnews/dto/response/article/ArticleNytDto.java
+++ b/src/main/java/org/mjulikelion/engnews/dto/response/article/ArticleNytDto.java
@@ -1,0 +1,28 @@
+package org.mjulikelion.engnews.dto.response.article;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class ArticleNytDto {
+    private String title;
+    private String imageUrl;
+    private String content;
+    private String time;
+    private String journalistName;
+    private Boolean isArticleLike;
+
+    // 정적 팩토리 메서드로 객체 생성
+    public static ArticleNytDto from(String title, String imageUrl, String content, String time, String journalistName, Boolean isArticleLike) {
+        return ArticleNytDto.builder()
+                .title(title)
+                .imageUrl(imageUrl)
+                .content(content)
+                .time(time)
+                .journalistName(journalistName)
+                .isArticleLike(isArticleLike)
+                .build();
+    }
+}

--- a/src/main/java/org/mjulikelion/engnews/response/ArticleResponse.java
+++ b/src/main/java/org/mjulikelion/engnews/response/ArticleResponse.java
@@ -1,0 +1,47 @@
+package org.mjulikelion.engnews.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ArticleResponse {
+    private Response response;
+
+    @Getter
+    @Setter
+    public static class Response {
+        private List<Doc> docs;
+
+        @Getter
+        @Setter
+        public static class Doc {
+            private String web_url; // 기사 URL
+            private String snippet; // 요약된 내용
+            private String pub_date; // 발행 날짜
+            private Headline headline; // 기사 제목
+            private Byline byline; // 기자 정보
+            private List<Multimedia> multimedia; // 멀티미디어 정보
+
+            @Getter
+            @Setter
+            public static class Headline {
+                private String main; // 메인 제목
+            }
+
+            @Getter
+            @Setter
+            public static class Byline {
+                private String original; // 기자 이름
+            }
+
+            @Getter
+            @Setter
+            public static class Multimedia {
+                private String url; // 이미지 URL
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🚀Description
NYT 단건 기사 조회 로직 수정

## 🛠️Changes
### Controller
- [x] NytNewsController

### Service
- [x] NytNewsService

### DTO
- [x] ArticleResponse
- [x] ArticleNytDto

## 🏷memo

Closes #102 